### PR TITLE
Add externalData subcollection to firestore rules

### DIFF
--- a/firebase/admin/firestore.rules
+++ b/firebase/admin/firestore.rules
@@ -281,6 +281,12 @@ service cloud.firestore {
 
       allow update: if isCurrentAdmin() || editingMyData();
 
+      match /externalData/{dataSource} {
+        allow read: if canReadExistingUser();
+        allow create: if canCreateUser();
+        allow update: if isCurrentAdmin() || editingMyData();
+      }
+
       // TODO: Adam start a Slack thread about admin access to assignments
       // TODO: Should current admins see previous assignments from other orgs (Adam's guess: yes???)
 


### PR DESCRIPTION
It was discovered that subcollections need to be given separate rules in the firebase rules. I realized this when dealing with the externalData subcollection on users. 

This PR adds externalData access to anyone with a matching permission to access the user. In effect, this rule should make externalData accessible whenever the user collection is.