### PR TITLE
Add task info to assignment get

### DIFF
--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -651,7 +651,7 @@ export class RoarFirekit {
         return {
           ...docData,
           task: taskData,
-        } as IAssignmentData;
+        } as unknown as IAssignmentData;
       }
     }
   }

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -34,6 +34,7 @@ import {
   onSnapshot,
   runTransaction,
   updateDoc,
+  DocumentData
 } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 
@@ -489,6 +490,7 @@ export class RoarFirekit {
         app: {
           user: doc(this.app.db, 'users', this.roarUid!),
           runs: collection(this.app.db, 'users', this.roarUid!, 'runs'),
+          tasks: collection(this.app.db, 'tasks'),
         },
       };
     } else {
@@ -639,9 +641,18 @@ export class RoarFirekit {
     this._verifyAuthentication();
     const docRef = doc(this.dbRefs!.admin.assignments, administrationId);
     const docSnap = await getDoc(docRef);
-
-    if (docSnap.exists()) {
-      return docSnap.data() as IAssignmentData;
+    if(docSnap.exists()) {
+      const docData = docSnap.data() as IAssessmentData;
+      const taskId = _get(docData, 'taskId');
+      const taskDocRef = doc(this.dbRefs!.app.tasks, taskId);
+      const taskDocSnap = await getDoc(taskDocRef);
+      if(taskDocSnap.exists()){
+        const taskData = taskDocSnap.data() as DocumentData;
+        return {
+          ...docData,
+          task: taskData,
+        } as IAssignmentData;
+      }
     }
   }
 

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -35,7 +35,6 @@ import {
   onSnapshot,
   runTransaction,
   updateDoc,
-  DocumentData
 } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 
@@ -643,7 +642,7 @@ export class RoarFirekit {
     const docRef = doc(this.dbRefs!.admin.assignments, administrationId);
     const docSnap = await getDoc(docRef);
     if(docSnap.exists()) {
-      const docData = docSnap.data() as IAssessmentData;
+      const docData = docSnap.data() as IAssignmentData;
       const assessments = _get(docData, 'assessments', []);
       const extendedAssessmentData = [] as IAssignedAssessmentData[];
       // Loop through these assessments and append their task data to docData
@@ -665,7 +664,7 @@ export class RoarFirekit {
       return {
         ...docData,
         assessments: extendedAssessmentData,
-      } as unknown as IAssignmentData
+      } as IAssignmentData
     }
   }
 

--- a/src/firestore/interfaces.ts
+++ b/src/firestore/interfaces.ts
@@ -135,7 +135,6 @@ export interface IAssignmentData extends DocumentData {
   dateClosed: Date;
   assigningOrgs: IOrgLists;
   assessments: IAssignedAssessmentData[];
-  task?: DocumentData;
 }
 
 export interface IDistrict extends DocumentData {

--- a/src/firestore/interfaces.ts
+++ b/src/firestore/interfaces.ts
@@ -135,6 +135,7 @@ export interface IAssignmentData extends DocumentData {
   dateClosed: Date;
   assigningOrgs: IOrgLists;
   assessments: IAssignedAssessmentData[];
+  task?: DocumentData;
 }
 
 export interface IDistrict extends DocumentData {


### PR DESCRIPTION
This PR adds the general task information to the getAssignments function. This is very helpful for populating the participant view on the front end when retrieving the user's assignments.