### PR TITLE
resolves promise issue related to getAssignments

### DIFF
--- a/src/__tests__/__utils__/firebaseConfig.ts
+++ b/src/__tests__/__utils__/firebaseConfig.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app';
-import { collection, connectFirestoreEmulator, doc, getFirestore } from 'firebase/firestore';
+import { connectFirestoreEmulator, getFirestore } from 'firebase/firestore';
 
 import { EmulatorConfigData } from '../../firestore/util';
 

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -654,7 +654,7 @@ export class RoarFirekit {
             taskData: taskDocSnap.data()
           };
         }
-      }))
+      }));
       return {
         ...docData,
         assessments: extendedAssessmentData,

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -8,7 +8,6 @@ import _keys from 'lodash/keys';
 import _map from 'lodash/map';
 import _nth from 'lodash/nth';
 import _union from 'lodash/union';
-import _forEach from 'lodash/forEach';
 import {
   AuthError,
   GoogleAuthProvider,

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -644,23 +644,17 @@ export class RoarFirekit {
     if(docSnap.exists()) {
       const docData = docSnap.data() as IAssignmentData;
       const assessments = _get(docData, 'assessments', []);
-      const extendedAssessmentData = [] as IAssignedAssessmentData[];
       // Loop through these assessments and append their task data to docData
-      _forEach(assessments, async (assessment) => {
+      const extendedAssessmentData = await Promise.all(assessments.map(async (assessment) => {
         const taskDocRef = doc(this.dbRefs!.app.tasks, assessment.taskId);
         const taskDocSnap = await getDoc(taskDocRef);
-        if (taskDocSnap.exists()) {
-          extendedAssessmentData.push({
-            ...taskDocSnap.data(),
+        if (taskDocSnap.exists()){
+          return {
             ...assessment,
-          });
-        } else {
-          // Doc not found. If we get here, it means that an assignment was somehow created with assessments that don't exist in the assessment firestore.
-          // Maybe we should throw an error. But it's not really the client's fault.
-          // A better solution would be to automatically open a ticket in some ticketing system that we haven't yet created.
+            taskData: taskDocSnap.data()
+          };
         }
-      });
-      
+      }))
       return {
         ...docData,
         assessments: extendedAssessmentData,
@@ -668,9 +662,9 @@ export class RoarFirekit {
     }
   }
 
-  getAssignments(administrationIds: string[]): Promise<IAssignmentData | undefined>[] {
+  async getAssignments(administrationIds: string[]): Promise<(IAssignmentData | undefined)[]> {
     this._verifyAuthentication();
-    return administrationIds.map((id) => this._getAssignment(id));
+    return await Promise.all(_map(administrationIds, async (id) => await this._getAssignment(id)));
   }
 
   async startAssignment(administrationId: string, transaction?: Transaction) {


### PR DESCRIPTION
This PR fixes an issue we were seeing with the getAssignments function. The issue was that in the private _getAssignments function, we try to add task data to each assessment, however we try to do this in a forEach loop which doesn't allow the asynchronous functions to fully execute before moving to the next. To solve this, we move this task to a map, and wrap the entire logic in a Promise.all, which will not continue executing until all promises have resolved.