### PR TITLE
Update run scores

### DIFF
--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -1,4 +1,4 @@
-import { removeNull } from '../firestore/util';
+import { removeNull, removeUndefined } from '../firestore/util';
 
 describe('removeNull', () => {
   it('removes null values', () => {
@@ -7,13 +7,13 @@ describe('removeNull', () => {
       b: 'foo',
       c: null,
       d: '',
-      e: undefined,
+      e: null,
       f: {
         g: 1,
         h: 'foo',
         i: null,
         j: '',
-        k: undefined,
+        k: null,
       },
     };
 
@@ -26,10 +26,44 @@ describe('removeNull', () => {
         h: 'foo',
         i: null,
         j: '',
-        k: undefined,
+        k: null,
       },
     };
 
     expect(removeNull(input)).toStrictEqual(expected);
+  });
+});
+
+describe('removeUndefined', () => {
+  it('removes null values', () => {
+    const input = {
+      a: 1,
+      b: 'foo',
+      c: undefined,
+      d: '',
+      e: undefined,
+      f: {
+        g: 1,
+        h: 'foo',
+        i: undefined,
+        j: '',
+        k: undefined,
+      },
+    };
+
+    const expected = {
+      a: 1,
+      b: 'foo',
+      d: '',
+      f: {
+        g: 1,
+        h: 'foo',
+        i: undefined,
+        j: '',
+        k: undefined,
+      },
+    };
+
+    expect(removeUndefined(input)).toStrictEqual(expected);
   });
 });

--- a/src/firestore/app/appkit.ts
+++ b/src/firestore/app/appkit.ts
@@ -168,8 +168,10 @@ export class RoarAppkit {
    * Add new trial data to this run on Firestore.
    *
    * ROAR expects certain data to be added to each trial:
+   * - assessment_stage: string, either practice_response or test_response
    * - correct: boolean, whether the correct answer was correct
-   * - theta: number (optional), the ability estimate for adaptive assessments
+   * - subtask: string (optional), the name of the subtask
+   * - thetaEstimate: number (optional), the ability estimate for adaptive assessments
    * - thetaSE: number (optional), the standard error of the ability estimate for adaptive assessments
    *
    * This method can be added to individual jsPsych trials by calling it from

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -49,7 +49,7 @@ export const convertTrialToFirestore = (trialData: object): object => {
 const requiredTrialFields = ['assessment_stage', 'correct'];
 
 interface ISummaryScores {
-  theta: number | null;
+  thetaEstimate: number | null;
   thetaSE: number | null;
   numAttempted: number;
   numCorrect: number;
@@ -241,7 +241,7 @@ export class RoarRun {
           // Then this subtask has already been added to this run.
           // Simply update the block's scores.
           this.scores.raw[subtask][stage] = {
-            theta: (trialData.theta as number) || null,
+            thetaEstimate: (trialData.thetaEstimate as number) || null,
             thetaSE: (trialData.thetaSE as number) || null,
             numAttempted: (this.scores.raw[subtask][stage]?.numAttempted || 0) + 1,
             numCorrect: (this.scores.raw[subtask][stage]?.numCorrect || 0) + +Boolean(trialData.correct),
@@ -250,7 +250,7 @@ export class RoarRun {
 
           // And populate the score update for Firestore.
           scoreUpdate = {
-            [`scores.raw.${subtask}.${stage}.theta`]: (trialData.theta as number) || null,
+            [`scores.raw.${subtask}.${stage}.thetaEstimate`]: (trialData.thetaEstimate as number) || null,
             [`scores.raw.${subtask}.${stage}.thetaSE`]: (trialData.thetaSE as number) || null,
             [`scores.raw.${subtask}.${stage}.numAttempted`]: increment(1),
             [`scores.raw.${subtask}.${stage}.numCorrect`]: trialData.correct ? increment(1) : null,
@@ -260,7 +260,7 @@ export class RoarRun {
           // This is the first time this subtask has been added to this run.
           // Initialize the subtask scores.
           this.scores.raw[subtask][stage] = {
-            theta: (trialData.theta as number) || null,
+            thetaEstimate: (trialData.thetaEstimate as number) || null,
             thetaSE: (trialData.thetaSE as number) || null,
             numAttempted: 1,
             numCorrect: trialData.correct ? 1 : 0,
@@ -269,7 +269,7 @@ export class RoarRun {
 
           // And populate the score update for Firestore.
           scoreUpdate = {
-            [`scores.raw.${subtask}.${stage}.theta`]: null,
+            [`scores.raw.${subtask}.${stage}.thetaEstimate`]: null,
             [`scores.raw.${subtask}.${stage}.thetaSE`]: null,
             [`scores.raw.${subtask}.${stage}.numAttempted`]: 1,
             [`scores.raw.${subtask}.${stage}.numCorrect`]: trialData.correct ? 1 : 0,

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -1,5 +1,4 @@
 import {
-  DocumentData,
   FieldValue,
   arrayUnion,
   collection,
@@ -12,11 +11,14 @@ import {
   updateDoc,
 } from 'firebase/firestore';
 import _intersection from 'lodash/intersection';
+import _mapValues from 'lodash/mapValues';
 import _pick from 'lodash/pick';
+import dot from 'dot-object';
 import { RoarTaskVariant } from './task';
 import { RoarAppUser } from './user';
 import { IOrgLists } from '../interfaces';
-import { removeNull } from '../util';
+import { removeUndefined } from '../util';
+import { FirebaseError } from '@firebase/util';
 
 /**
  * Convert a trial data to allow storage on Cloud Firestore.
@@ -29,25 +31,46 @@ import { removeNull } from '../util';
  * @returns {Object} Converted trial data
  */
 export const convertTrialToFirestore = (trialData: object): object => {
-  return Object.fromEntries(
-    Object.entries(trialData).map(([key, value]) => {
-      if (value instanceof URL) {
-        return [key, value.toString()];
-      } else if (typeof value === 'object' && value !== null) {
-        return [key, convertTrialToFirestore(value)];
-      } else {
-        return [key, value];
-      }
-    }),
+  return removeUndefined(
+    Object.fromEntries(
+      Object.entries(trialData).map(([key, value]) => {
+        if (value instanceof URL) {
+          return [key, value.toString()];
+        } else if (typeof value === 'object' && value !== null) {
+          return [key, convertTrialToFirestore(value)];
+        } else {
+          return [key, value];
+        }
+      }),
+    ),
   );
 };
 
-export interface IRunScores extends DocumentData {
+const requiredTrialFields = ['assessment_stage', 'correct'];
+
+interface ISummaryScores {
   theta: number | null;
   thetaSE: number | null;
-  numAttempted: FieldValue;
-  numCorrect: FieldValue;
-  numIncorrect: FieldValue;
+  numAttempted: number;
+  numCorrect: number;
+  numIncorrect: number;
+}
+
+interface IRawScores {
+  [key: string]: {
+    practice: ISummaryScores;
+    test: ISummaryScores;
+  };
+}
+
+interface IComputedOrNormedScores {
+  [key: string]: number | null;
+}
+
+export interface IRunScores {
+  raw: IRawScores;
+  computed: IComputedOrNormedScores;
+  normed: IComputedOrNormedScores;
 }
 
 export interface IRunInput {
@@ -55,6 +78,10 @@ export interface IRunInput {
   task: RoarTaskVariant;
   assigningOrgs?: IOrgLists;
   runId?: string;
+}
+
+interface IScoreUpdate {
+  [key: string]: number | FieldValue | null;
 }
 
 /**
@@ -70,6 +97,8 @@ export class RoarRun {
   assigningOrgs?: IOrgLists;
   started: boolean;
   completed: boolean;
+  subtasks: string[];
+  scores: IRunScores;
   /** Create a ROAR run
    * @param {IRunInput} input
    * @param {RoarAppUser} input.user - The user running the task
@@ -93,6 +122,13 @@ export class RoarRun {
     }
     this.started = false;
     this.completed = false;
+
+    this.subtasks = [];
+    this.scores = {
+      raw: {},
+      computed: {},
+      normed: {},
+    };
   }
 
   /**
@@ -129,16 +165,10 @@ export class RoarRun {
       completed: false,
       timeStarted: serverTimestamp(),
       timeFinished: null,
-      numAttempted: 0,
-      numCorrect: 0,
-      numIncorrect: 0,
-      theta: null,
-      thetaSE: null,
     };
 
-    await setDoc(this.runRef, removeNull(runData))
+    await setDoc(this.runRef, removeUndefined(runData))
       .then(() => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return updateDoc(this.user.userRef, {
           tasks: arrayUnion(this.task.taskId),
           variants: arrayUnion(this.task.variantId),
@@ -173,10 +203,25 @@ export class RoarRun {
    * @async
    * @param {*} trialData - An object containing trial data.
    */
-  async writeTrial(trialData: Record<string, unknown>) {
+  async writeTrial(
+    trialData: Record<string, unknown>,
+    computedScoreCallback?: (rawScores: IRawScores) => IComputedOrNormedScores,
+    normedScoreCallback?: (computedScores: IComputedOrNormedScores) => IComputedOrNormedScores,
+  ) {
     if (!this.started) {
       throw new Error('Run has not been started yet. Use the startRun method first.');
     }
+
+    // Check that the trial has all of the required reserved keys
+    if (!requiredTrialFields.every((key) => key in trialData)) {
+      throw new Error(
+        'All ROAR trials saved to Firestore must have the following reserved keys: ' +
+          `${requiredTrialFields}.` +
+          'The current trial is missing the following required keys: ' +
+          `${requiredTrialFields.filter((key) => !(key in trialData))}.`,
+      );
+    }
+
     const trialRef = doc(collection(this.runRef, 'trials'));
 
     return setDoc(trialRef, {
@@ -184,19 +229,109 @@ export class RoarRun {
       serverTimestamp: serverTimestamp(),
     })
       .then(() => {
-        const runScores = {
-          numAttempted: increment(1),
-          theta: trialData.theta || null,
-          thetaSE: trialData.thetaSE || null,
-        } as IRunScores;
+        // Here we update the scores for this run. We create scores for each subtask in the task.
+        // E.g., ROAR-PA has three subtasks: FSM, LSM, and DEL. Each subtask has its own score.
+        // Conversely, ROAR-SWR has no subtasks. It's scores are stored in the 'total' score field.
+        // If no subtask is specified, the scores for the 'total' subtask will be updated.
+        const subtask = (trialData.subtask || 'total') as string;
+        const stage = trialData.assessment_stage === 'test_response' ? 'test' : 'practice';
 
-        if (trialData.correct) {
-          runScores.numCorrect = increment(1);
+        let scoreUpdate: IScoreUpdate = {};
+        if (subtask in this.scores.raw) {
+          // Then this subtask has already been added to this run.
+          // Simply update the block's scores.
+          this.scores.raw[subtask][stage] = {
+            theta: (trialData.theta as number) || null,
+            thetaSE: (trialData.thetaSE as number) || null,
+            numAttempted: (this.scores.raw[subtask][stage]?.numAttempted || 0) + 1,
+            numCorrect: (this.scores.raw[subtask][stage]?.numCorrect || 0) + +Boolean(trialData.correct),
+            numIncorrect: (this.scores.raw[subtask][stage]?.numIncorrect || 0) + +!trialData.correct,
+          };
+
+          // And populate the score update for Firestore.
+          scoreUpdate = {
+            [`scores.raw.${subtask}.${stage}.theta`]: (trialData.theta as number) || null,
+            [`scores.raw.${subtask}.${stage}.thetaSE`]: (trialData.thetaSE as number) || null,
+            [`scores.raw.${subtask}.${stage}.numAttempted`]: increment(1),
+            [`scores.raw.${subtask}.${stage}.numCorrect`]: trialData.correct ? increment(1) : null,
+            [`scores.raw.${subtask}.${stage}.numIncorrect`]: trialData.correct ? null : increment(1),
+          };
         } else {
-          runScores.numIncorrect = increment(1);
+          // This is the first time this subtask has been added to this run.
+          // Initialize the subtask scores.
+          this.scores.raw[subtask][stage] = {
+            theta: (trialData.theta as number) || null,
+            thetaSE: (trialData.thetaSE as number) || null,
+            numAttempted: 1,
+            numCorrect: trialData.correct ? 1 : 0,
+            numIncorrect: trialData.correct ? 0 : 1,
+          };
+
+          // And populate the score update for Firestore.
+          scoreUpdate = {
+            [`scores.raw.${subtask}.${stage}.theta`]: null,
+            [`scores.raw.${subtask}.${stage}.thetaSE`]: null,
+            [`scores.raw.${subtask}.${stage}.numAttempted`]: 1,
+            [`scores.raw.${subtask}.${stage}.numCorrect`]: trialData.correct ? 1 : 0,
+            [`scores.raw.${subtask}.${stage}.numIncorrect`]: trialData.correct ? 0 : 1,
+          };
         }
 
-        return updateDoc(this.runRef, runScores);
+        if (computedScoreCallback) {
+          // Use the user-provided callback to compute the computed scores.
+          this.scores.computed = computedScoreCallback(this.scores.raw);
+
+          // And use dot-object to convert the computed scores into dotted-key/value pairs.
+          // First nest the computed scores into `scores.computed` so that they get updated
+          // in the correct location.
+          const fullUpdatePath = {
+            scores: {
+              computed: this.scores.computed,
+            },
+          };
+          scoreUpdate = {
+            ...scoreUpdate,
+            ...dot.dot(fullUpdatePath),
+          };
+        } else {
+          // If no computedScoreCallback is provided, we default to
+          // numCorrect - numIncorrect for each subtask.
+          this.scores.computed = _mapValues(this.scores.raw, (subtaskScores) => {
+            if (subtaskScores.test?.numCorrect && subtaskScores.test?.numIncorrect) {
+              const computed = subtaskScores.test.numCorrect - subtaskScores.test.numIncorrect;
+              // Side effect: add the subtask computed scores to the scoreUpdate object.
+              scoreUpdate[`scores.computed.${subtask}`] = computed;
+              return computed;
+            }
+            return null;
+          });
+        }
+
+        if (normedScoreCallback) {
+          this.scores.normed = normedScoreCallback(this.scores.computed);
+          const fullUpdatePath = {
+            scores: {
+              normed: this.scores.normed,
+            },
+          };
+          scoreUpdate = {
+            ...scoreUpdate,
+            ...dot.dot(fullUpdatePath),
+          };
+        }
+
+        return updateDoc(this.runRef, removeUndefined(scoreUpdate)).catch((error: FirebaseError) => {
+          // Catch the "Unsupported field value: undefined" error and
+          // provide a more helpful error message to the ROAR app developer.
+          if (error.message.toLowerCase().includes('unsupported field value: undefined')) {
+            throw new Error(
+              'The computed or normed scores that you provided contained an undefined value. ' +
+                'Firestore does not support storing undefined values. ' +
+                'Please remove this value or convert it to ``null``.',
+            );
+          }
+          throw error;
+        });
       })
       .then(() => {
         this.user.updateFirestoreTimestamp();

--- a/src/firestore/app/task.ts
+++ b/src/firestore/app/task.ts
@@ -13,7 +13,7 @@ import {
   updateDoc,
   where,
 } from 'firebase/firestore';
-import { removeNull } from '../util';
+import { removeUndefined } from '../util';
 
 export interface ITaskVariantInfo {
   taskId: string;
@@ -105,7 +105,7 @@ export class RoarTaskVariant {
       description: this.taskDescription,
       lastUpdated: serverTimestamp(),
     };
-    await setDoc(this.taskRef, removeNull(taskData), { merge: true });
+    await setDoc(this.taskRef, removeUndefined(taskData), { merge: true });
 
     // Check to see if variant exists already by querying for a match on the
     // params.
@@ -124,7 +124,7 @@ export class RoarTaskVariant {
       this.variantRef = doc(this.variantsCollectionRef, this.variantId);
       updateDoc(
         this.variantRef,
-        removeNull({
+        removeUndefined({
           description: this.variantDescription,
           lastUpdated: serverTimestamp(),
         }),
@@ -141,7 +141,7 @@ export class RoarTaskVariant {
         lastUpdated: serverTimestamp(),
       };
       this.variantRef = doc(this.variantsCollectionRef);
-      await setDoc(this.variantRef, removeNull(variantData));
+      await setDoc(this.variantRef, removeUndefined(variantData));
       this.variantId = this.variantRef.id;
     }
   }

--- a/src/firestore/app/user.ts
+++ b/src/firestore/app/user.ts
@@ -11,7 +11,7 @@ import {
 } from 'firebase/firestore';
 import _extend from 'lodash/extend';
 import { UserType } from '../interfaces';
-import { removeNull } from '../util';
+import { removeUndefined } from '../util';
 
 export interface IUserInfo {
   roarUid?: string;
@@ -115,7 +115,7 @@ export class RoarAppUser {
     if (this.userType !== UserType.guest) {
       throw new Error('Cannot set user data on a non-guest ROAR user.');
     }
-    this.userData = removeNull({
+    this.userData = removeUndefined({
       ...this.userMetadata,
       assessmentPid: this.assessmentPid,
       assessmentUid: this.assessmentUid,
@@ -174,7 +174,7 @@ export class RoarAppUser {
       assessmentPid,
     });
 
-    return updateDoc(this.userRef, removeNull(userData));
+    return updateDoc(this.userRef, removeUndefined(userData));
   }
 
   /**

--- a/src/firestore/util.ts
+++ b/src/firestore/util.ts
@@ -14,14 +14,24 @@ import _get from 'lodash/get';
 import _isEqual from 'lodash/isEqual';
 import { markRaw } from 'vue';
 
-/** Remove null and undefined attributes from an object
+/** Remove null attributes from an object
  * @function
  * @param {Object} obj - Object to remove null attributes from
  * @returns {Object} Object with null attributes removed
  */
 export const removeNull = (obj: object): object => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v !== null && v !== undefined));
+  return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v !== null));
+};
+
+/** Remove undefined attributes from an object
+ * @function
+ * @param {Object} obj - Object to remove undefined attributes from
+ * @returns {Object} Object with undefined attributes removed
+ */
+export const removeUndefined = (obj: object): object => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v !== undefined));
 };
 
 export interface CommonFirebaseConfig {


### PR DESCRIPTION
This PR:
- Separates the `removeNull` utility function into separate `removeNull` and `removeUndefined` utility functions.
- Validates trial data by ensuring it has certain required fields, namely `assessment_stage` and `correct`
- Update run scores in three categories (raw, computed, normed) by subtask
- Allows user to supply callbacks for computed and normed scores
- If no callback is supplied for the computed scores, it defaults to `numCorrect - numIncorrect`
- If no callback is supplied for the normed scores, it does not write normed scores.