### PR TITLE
Update student registration function

### DIFF
--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -935,8 +935,8 @@ export class RoarFirekit {
 
     const isEmailAvailable = await this.isEmailAvailable(email);
     if (isEmailAvailable) {
-      if (!(_get(userData, 'age_year') || _get(userData, 'age_month') || _get(userData, 'dob'))) {
-        throw new Error('Either age or date of birth must be supplied.');
+      if (!_get(userData, 'dob')) {
+        throw new Error('Student date of birth must be supplied.');
       }
 
       const userDocData: IUserData = {
@@ -951,19 +951,6 @@ export class RoarFirekit {
       };
 
       if (_get(userData, 'name')) _set(userDocData, 'name', userData.name);
-      if (!_get(userData, 'dob')) {
-        let ageInMonths: number;
-        if (_get(userData, 'age_year')) {
-          ageInMonths = Math.round(Number(userData.age_year) * 12);
-        }
-        // Default to age_month if given both fields
-        if (_get(userData, 'age_month')) {
-          ageInMonths = Math.round(Number(userData.age_month));
-        }
-        const calcDob = new Date();
-        calcDob.setMonth(calcDob.getMonth() - ageInMonths!);
-        _set(userDocData, 'studentData.dob', calcDob);
-      }
       if (_get(userData, 'dob')) _set(userDocData, 'studentData.dob', userData.dob);
       if (_get(userData, 'gender')) _set(userDocData, 'studentData.gender', userData.gender);
       if (_get(userData, 'ell_status')) _set(userDocData, 'studentData.ell_status', userData.ell_status);

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -955,7 +955,9 @@ export class RoarFirekit {
         let ageInMonths: number;
         if (_get(userData, 'age_year')) {
           ageInMonths = Math.round(Number(userData.age_year) * 12);
-        } else if (_get(userData, 'age_month')) {
+        }
+        // Default to age_month if given both fields
+        if (_get(userData, 'age_month')) {
           ageInMonths = Math.round(Number(userData.age_month));
         }
         const calcDob = new Date();
@@ -1011,16 +1013,16 @@ export class RoarFirekit {
           },
         });
       }
-      const cloudCreateAdminStudent = httpsCallable(this.admin!.functions, 'createstudent');
+      const cloudCreateAdminStudent = httpsCallable(this.admin!.functions, 'createstudentaccount');
       const adminResponse = await cloudCreateAdminStudent({ email, password, userDocData });
       const adminUid = _get(adminResponse, 'data.adminUid');
 
-      const cloudCreateAppStudent = httpsCallable(this.app!.functions, 'createstudent');
+      const cloudCreateAppStudent = httpsCallable(this.app!.functions, 'createstudentaccount');
       const appResponse = await cloudCreateAppStudent({ adminUid, email, password, userDocData });
       // cloud function returns all relevant Uids (since at this point, all of the associations and claims have been made)
       const assessmentUid = _get(appResponse, 'data.assessmentUid');
 
-      const cloudUpdateUserClaims = httpsCallable(this.admin!.functions, 'associateAssessmentUid');
+      const cloudUpdateUserClaims = httpsCallable(this.admin!.functions, 'associateassessmentuid');
       await cloudUpdateUserClaims({ adminUid, assessmentUid });
     } else {
       // Email is not available, reject

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -70,9 +70,7 @@ const RoarProviderId = {
 };
 
 interface ICreateUserInput {
-  age_month: string | null;
-  age_year: string | null;
-  dob: string | null;
+  dob: string;
   grade: string;
   ell_status?: boolean;
   iep_status?: boolean;
@@ -957,55 +955,18 @@ export class RoarFirekit {
       if (_get(userData, 'iep_status')) _set(userDocData, 'studentData.iep_status', userData.iep_status);
       if (_get(userData, 'frl_status')) _set(userDocData, 'studentData.frl_status', userData.frl_status);
 
-      const dateNow = Date.now();
-      // create district entry
-      const districtId = _get(userData, 'district');
-      if (districtId) {
-        _set(userDocData, 'districts', {
-          current: [districtId],
-          all: [districtId],
-          dates: {
-            [districtId!]: {
-              from: dateNow,
-              to: null,
-            },
-          },
-        });
-      }
-      // create school entry
-      const schoolId = _get(userData, 'school');
-      if (schoolId) {
-        _set(userDocData, 'schools', {
-          current: [schoolId],
-          all: [schoolId],
-          dates: {
-            [schoolId!]: {
-              from: dateNow,
-              to: null,
-            },
-          },
-        });
-      }
-      // create class entry
-      const classId = _get(userData, 'class');
-      if (classId) {
-        _set(userDocData, 'classes', {
-          current: [classId],
-          all: [classId],
-          dates: {
-            [classId!]: {
-              from: dateNow,
-              to: null,
-            },
-          },
-        });
-      }
+      if(_get(userData, 'district')) _set(userDocData, 'orgIds.district', userData.district);
+      if(_get(userData, 'school')) _set(userDocData, 'orgIds.school', userData.school);
+      if(_get(userData, 'class')) _set(userDocData, 'orgIds.class', userData.class);
+      if(_get(userData, 'study')) _set(userDocData, 'orgIds.study', userData.study);
+      if(_get(userData, 'family')) _set(userDocData, 'orgIds.family', userData.family);
+
       const cloudCreateAdminStudent = httpsCallable(this.admin!.functions, 'createstudentaccount');
-      const adminResponse = await cloudCreateAdminStudent({ email, password, userDocData });
+      const adminResponse = await cloudCreateAdminStudent({ email, password, userData: userDocData });
       const adminUid = _get(adminResponse, 'data.adminUid');
 
       const cloudCreateAppStudent = httpsCallable(this.app!.functions, 'createstudentaccount');
-      const appResponse = await cloudCreateAppStudent({ adminUid, email, password, userDocData });
+      const appResponse = await cloudCreateAppStudent({ adminUid, email, password, userData: userDocData });
       // cloud function returns all relevant Uids (since at this point, all of the associations and claims have been made)
       const assessmentUid = _get(appResponse, 'data.assessmentUid');
 


### PR DESCRIPTION
This PR:
- Drops support for age_year and age_month
- Fixes issue where Org 'dates' are not timestamps (In conjunction with [This PR](https://github.com/yeatmanlab/roar-firebase-functions/pull/128))

Specifically, this PR moves the creation of populated org object to the cloud function itself. This is because when they are created in firekit, the date objects are stringified, thus will not be converted to timestamps when written to the user document. 
The solution here is to move the construction of those org objects to the cloud function itself. That way firebase can translate the complete date objects to timestamps when writing to the user document.