### PR TITLE
Make PID unidentifiable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.8.8",
       "license": "ISC",
       "dependencies": {
+        "crc-32": "^1.2.2",
         "dot-object": "^2.1.4",
         "firebase": "^9.23.0",
         "lodash": "^4.17.21",
@@ -2775,6 +2776,17 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lib/**/*"
   ],
   "dependencies": {
+    "crc-32": "^1.2.2",
     "dot-object": "^2.1.4",
     "firebase": "^9.23.0",
     "lodash": "^4.17.21",

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -1,4 +1,10 @@
+<<<<<<< HEAD
 import { getObjectDiff, removeNull, removeUndefined, replaceValues } from '../firestore/util';
+||||||| parent of 44ab7fd (Add crc32String and compute checksum of email as PID)
+import { removeNull, removeUndefined } from '../firestore/util';
+=======
+import { crc32String, removeNull, removeUndefined } from '../firestore/util';
+>>>>>>> 44ab7fd (Add crc32String and compute checksum of email as PID)
 
 describe('removeNull', () => {
   it('removes null values', () => {
@@ -119,5 +125,14 @@ describe('replaceValues', () => {
 
     expect(result1).toStrictEqual(expected1);
     expect(result2).toStrictEqual(expected2);
+  });
+});
+
+describe('crc32String', () => {
+  it('computes a checksum of emails', () => {
+    const input = 'roar@stanford.edu';
+    const expected = '5a036850';
+
+    expect(crc32String(input)).toBe(expected);
   });
 });

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -1,10 +1,4 @@
-<<<<<<< HEAD
-import { getObjectDiff, removeNull, removeUndefined, replaceValues } from '../firestore/util';
-||||||| parent of 44ab7fd (Add crc32String and compute checksum of email as PID)
-import { removeNull, removeUndefined } from '../firestore/util';
-=======
-import { crc32String, removeNull, removeUndefined } from '../firestore/util';
->>>>>>> 44ab7fd (Add crc32String and compute checksum of email as PID)
+import { crc32String, getObjectDiff, removeNull, removeUndefined, replaceValues } from '../firestore/util';
 
 describe('removeNull', () => {
   it('removes null values', () => {

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -1020,7 +1020,7 @@ export class RoarFirekit {
     // }
   }
 
-  async createStudentWithEmailPassword(email: string, password: string, userData: ICreateUserInput) {
+  async createStudentWithEmailPassword(email: string, password: string, userData: ICreateUserInput, pidPrefix = '') {
     this._verifyAuthentication();
     this._verifyAdmin();
 
@@ -1045,7 +1045,7 @@ export class RoarFirekit {
         _set(userDocData, 'assessmentPid', userData.pid);
       } else {
         const emailCheckSum = crc32String(email);
-        _set(userDocData, 'assessmentPid', emailCheckSum);
+        _set(userDocData, 'assessmentPid', pidPrefix + emailCheckSum);
       }
 
       // TODO: this can probably be optimized.
@@ -1085,14 +1085,19 @@ export class RoarFirekit {
     }
   }
 
-  async createStudentWithUsernamePassword(username: string, password: string, userData: ICreateUserInput) {
+  async createStudentWithUsernamePassword(
+    username: string,
+    password: string,
+    userData: ICreateUserInput,
+    pidPrefix = '',
+  ) {
     this._verifyAuthentication();
     this._verifyAdmin();
 
     const isUsernameAvailable = await this.isUsernameAvailable(username);
     if (isUsernameAvailable) {
       const email = `${username}@roar-auth.com`;
-      await this.createStudentWithEmailPassword(email, password, userData);
+      await this.createStudentWithEmailPassword(email, password, userData, pidPrefix);
     } else {
       // Username is not available, reject
       throw new Error(`The username ${username} is not available.`);

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -79,6 +79,7 @@ const RoarProviderId = {
 interface ICreateUserInput {
   dob: string;
   grade: string;
+  pid?: string;
   ell_status?: boolean;
   iep_status?: boolean;
   frl_status?: boolean;
@@ -147,6 +148,7 @@ export class RoarFirekit {
     this.userData = undefined;
     this.roarAppUserInfo = undefined;
     this._adminOrgs = undefined;
+    this._superAdmin = undefined;
     this.currentAssignments = undefined;
     this.oAuthAccessToken = undefined;
     this._adminClaimsListener = undefined;
@@ -1039,7 +1041,13 @@ export class RoarFirekit {
         archived: false,
       };
 
-      // TODO: this can probably be optimized.
+      if (_get(userData, 'pid')){
+        _set(userDocData, 'pid', userData.pid)
+      } else {
+        // Adam: create a PID, set it like on L#1005
+      }
+
+      // TODO: this can probably be optimized. 
       if (_get(userData, 'name')) _set(userDocData, 'name', userData.name);
       if (_get(userData, 'dob')) _set(userDocData, 'studentData.dob', userData.dob);
       if (_get(userData, 'gender')) _set(userDocData, 'studentData.gender', userData.gender);

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -8,8 +8,6 @@ import _keys from 'lodash/keys';
 import _map from 'lodash/map';
 import _nth from 'lodash/nth';
 import _union from 'lodash/union';
-import _head from 'lodash/head';
-import _split from 'lodash/split';
 import {
   AuthError,
   GoogleAuthProvider,
@@ -43,7 +41,7 @@ import {
 import { httpsCallable } from 'firebase/functions';
 
 import { isEmailAvailable, isUsernameAvailable, roarEmail } from '../auth';
-import { AuthPersistence, MarkRawConfig, emptyOrg, emptyOrgList, initializeFirebaseProject } from './util';
+import { AuthPersistence, MarkRawConfig, crc32String, emptyOrg, emptyOrgList, initializeFirebaseProject } from './util';
 import {
   IAdministrationData,
   IAssessmentData,
@@ -1043,15 +1041,14 @@ export class RoarFirekit {
         archived: false,
       };
 
-      if (_get(userData, 'pid')){
-        _set(userDocData, 'assessmentPid', userData.pid)
+      if (_get(userData, 'pid')) {
+        _set(userDocData, 'assessmentPid', userData.pid);
       } else {
-        // Adam: create a PID, set it like on L#1005
-        _set(userDocData, 'assessmentPid', _head(_split(email, "@")))
-        // Also _head and _split imports can be excluded if not used here.
+        const emailCheckSum = crc32String(email);
+        _set(userDocData, 'assessmentPid', emailCheckSum);
       }
 
-      // TODO: this can probably be optimized. 
+      // TODO: this can probably be optimized.
       if (_get(userData, 'name')) _set(userDocData, 'name', userData.name);
       if (_get(userData, 'dob')) _set(userDocData, 'studentData.dob', userData.dob);
       if (_get(userData, 'gender')) _set(userDocData, 'studentData.gender', userData.gender);

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -8,6 +8,8 @@ import _keys from 'lodash/keys';
 import _map from 'lodash/map';
 import _nth from 'lodash/nth';
 import _union from 'lodash/union';
+import _head from 'lodash/head';
+import _split from 'lodash/split';
 import {
   AuthError,
   GoogleAuthProvider,
@@ -1045,6 +1047,8 @@ export class RoarFirekit {
         _set(userDocData, 'pid', userData.pid)
       } else {
         // Adam: create a PID, set it like on L#1005
+        _set(userDocData, '', _head(_split(email, "@")))
+        // Also _head and _split imports can be excluded if not used here.
       }
 
       // TODO: this can probably be optimized. 

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -1044,10 +1044,10 @@ export class RoarFirekit {
       };
 
       if (_get(userData, 'pid')){
-        _set(userDocData, 'pid', userData.pid)
+        _set(userDocData, 'assessmentPid', userData.pid)
       } else {
         // Adam: create a PID, set it like on L#1005
-        _set(userDocData, '', _head(_split(email, "@")))
+        _set(userDocData, 'assessmentPid', _head(_split(email, "@")))
         // Also _head and _split imports can be excluded if not used here.
       }
 

--- a/src/firestore/util.ts
+++ b/src/firestore/util.ts
@@ -14,6 +14,7 @@ import _get from 'lodash/get';
 import _isEqual from 'lodash/isEqual';
 import _isPlainObject from 'lodash/isPlainObject';
 import { markRaw } from 'vue';
+import { str as crc32 } from 'crc-32';
 
 /** Remove null attributes from an object
  * @function
@@ -272,4 +273,16 @@ export const getObjectDiff = (obj1: { [key: string]: unknown }, obj2: { [key: st
   }, Object.keys(obj2));
 
   return diff;
+};
+
+export const crc32String = (inputString: string) => {
+  const modulo = (a: number, b: number) => {
+    return a - Math.floor(a / b) * b;
+  };
+
+  const toUint32 = (x: number) => {
+    return modulo(x, Math.pow(2, 32));
+  };
+
+  return toUint32(crc32(inputString)).toString(16);
 };


### PR DESCRIPTION
This PR exposes PID as an input parameter for student account creation. If one is not provided, it computes a crc32 checksum of the email.