### PR TITLE
Fix doc listeners

### DIFF
--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -275,6 +275,7 @@ export class RoarFirekit {
             // Update the user's ID token and refresh claimsLastUpdated.
             firekit.user!.getIdToken(true);
             firekit.claimsLastUpdated = lastUpdated;
+            this._userDocListener = this._listenToUserDoc();
           }
         }
       });

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -314,32 +314,20 @@ export class RoarFirekit {
     return appResult;
   }
 
-  private async _syncCleverData(oAuthAccessToken?: string, authProvider?: AuthProviderType) {
+  private async _syncCleverUser(oAuthAccessToken?: string, authProvider?: AuthProviderType) {
     if (authProvider === AuthProviderType.CLEVER) {
       if (oAuthAccessToken === undefined) {
         throw new Error('No OAuth access token provided.');
       }
       this._verifyAuthentication();
-      const syncAdminCleverData = httpsCallable(this.admin!.functions, 'synccleverdata');
-      const adminResult = await syncAdminCleverData({
+      const syncCleverUser = httpsCallable(this.admin!.functions, 'syncCleverUser');
+      const adminResult = await syncCleverUser({
         assessmentUid: this.app!.user!.uid,
         accessToken: oAuthAccessToken,
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (_get(adminResult.data as any, 'status') !== 'ok') {
-        throw new Error('Failed to sync Clever and ROAR data.');
-      }
-
-      const syncAppCleverData = httpsCallable(this.app!.functions, 'synccleverdata');
-      const appResult = await syncAppCleverData({
-        adminUid: this.admin!.user!.uid,
-        roarUid: this.roarUid,
-        accessToken: oAuthAccessToken,
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if (_get(appResult.data as any, 'status') !== 'ok') {
         throw new Error('Failed to sync Clever and ROAR data.');
       }
     }
@@ -488,7 +476,7 @@ export class RoarFirekit {
       })
       .then((setClaimsResult) => {
         if (setClaimsResult) {
-          this._syncCleverData(oAuthAccessToken, provider);
+          this._syncCleverUser(oAuthAccessToken, provider);
         }
       });
   }
@@ -563,7 +551,7 @@ export class RoarFirekit {
       })
       .then((setClaimsResult) => {
         if (setClaimsResult) {
-          this._syncCleverData(oAuthAccessToken, authProvider);
+          this._syncCleverUser(oAuthAccessToken, authProvider);
         }
       });
   }

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -1309,6 +1309,21 @@ export class RoarFirekit {
     });
   }
 
+  async syncCleverOrgs(shallow = false) {
+    this._verifyAuthentication();
+    if (!this._superAdmin) {
+      throw new Error('You must be a super admin to sync Clever organizations.');
+    }
+
+    const syncCleverOrgs = httpsCallable(this.admin!.functions, 'syncCleverOrgs');
+    const result = await syncCleverOrgs({ shallow });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (_get(result.data as any, 'status') !== 'ok') {
+      throw new Error('Failed to sync Clever orgs.');
+    }
+  }
+
   async createOrg(orgsCollection: OrgCollectionName, orgData: IOrg) {
     this._verifyAuthentication();
     this._verifyAdmin();


### PR DESCRIPTION
This PR adds calls to `getMyData` in the ID token change listener. This is needed to authenticate a Clever user for the first time since a Clever user's Firestore doc does not exist when they first log in.