### PR TITLE
Reduce org chunk size in queries

### DIFF
--- a/src/firestore/app/appkit.ts
+++ b/src/firestore/app/appkit.ts
@@ -14,6 +14,7 @@ interface IAppkitConstructorParams {
   userInfo: IUserInfo;
   taskInfo: ITaskVariantInfo;
   assigningOrgs?: IOrgLists;
+  assignmentId?: string;
   runId?: string;
 }
 
@@ -31,6 +32,7 @@ export class RoarAppkit {
   private _userInfo: IUserInfo;
   private _taskInfo: ITaskVariantInfo;
   private _assigningOrgs?: IOrgLists;
+  private _assignmentId?: string;
   private _runId?: string;
   private _authenticated: boolean;
   private _initialized: boolean;
@@ -42,9 +44,18 @@ export class RoarAppkit {
    * @param {IUserInfo} input.userInfo - The user input object
    * @param {ITaskVariantInfo} input.taskInfo - The task input object
    * @param {IOrgLists} input.assigningOrgs - The IDs of the orgs to which this run belongs
-   * @param {string} input.runId = The ID of the run. If undefined, a new run will be created.
+   * @param {string} input.assignmentId - The ID of the assignment this run belongs to
+   * @param {string} input.runId - The ID of the run. If undefined, a new run will be created.
    */
-  constructor({ firebaseProject, firebaseConfig, userInfo, taskInfo, assigningOrgs, runId }: IAppkitConstructorParams) {
+  constructor({
+    firebaseProject,
+    firebaseConfig,
+    userInfo,
+    taskInfo,
+    assigningOrgs,
+    assignmentId,
+    runId,
+  }: IAppkitConstructorParams) {
     if (!firebaseProject && !firebaseConfig) {
       throw new Error('You must provide either a firebaseProjectKit or firebaseConfig');
     }
@@ -59,6 +70,7 @@ export class RoarAppkit {
     this._userInfo = userInfo;
     this._taskInfo = taskInfo;
     this._assigningOrgs = assigningOrgs;
+    this._assignmentId = assignmentId;
     this._runId = runId;
 
     this._authenticated = false;
@@ -87,6 +99,7 @@ export class RoarAppkit {
       user: this.user,
       task: this.task,
       assigningOrgs: this._assigningOrgs,
+      assignmentId: this._assignmentId,
       runId: this._runId,
     });
     await this.user.init();

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -77,6 +77,7 @@ export interface IRunInput {
   user: RoarAppUser;
   task: RoarTaskVariant;
   assigningOrgs?: IOrgLists;
+  assignmentId?: string;
   runId?: string;
 }
 
@@ -103,6 +104,7 @@ export class RoarRun {
   task: RoarTaskVariant;
   runRef: DocumentReference;
   assigningOrgs?: IOrgLists;
+  assignmentId?: string;
   started: boolean;
   completed: boolean;
   aborted: boolean;
@@ -114,10 +116,11 @@ export class RoarRun {
    * @param {IOrgLists} input.assigningOrgs - The IDs of the orgs to which this run belongs
    * @param {string} input.runId = The ID of the run. If undefined, a new run will be created.
    */
-  constructor({ user, task, assigningOrgs, runId }: IRunInput) {
+  constructor({ user, task, assigningOrgs, assignmentId, runId }: IRunInput) {
     this.user = user;
     this.task = task;
     this.assigningOrgs = assigningOrgs;
+    this.assignmentId = assignmentId;
 
     if (runId) {
       this.runRef = doc(this.user.userRef, 'runs', runId);
@@ -167,7 +170,8 @@ export class RoarRun {
     const runData = {
       ...additionalRunMetadata,
       id: this.runRef.id,
-      assigningOrgs: this.assigningOrgs || null,
+      assignmentId: this.assignmentId ?? null,
+      assigningOrgs: this.assigningOrgs ?? null,
       taskId: this.task.taskId,
       variantId: this.task.variantId,
       completed: false,

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -60,7 +60,6 @@ import {
   IStudentData,
   IUserData,
   OrgCollectionName,
-  OrgType,
   UserType,
 } from './interfaces';
 import { IUserInput } from './app/user';
@@ -1341,7 +1340,7 @@ export class RoarFirekit {
     orgId,
     countOnly = false,
   }: {
-    orgType: OrgType;
+    orgType: OrgCollectionName;
     orgId: string;
     countOnly?: boolean;
   }) {

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -292,6 +292,7 @@ export class RoarFirekit {
           doc(firekit.db, 'userClaims', firekit.user!.uid),
           async (doc) => {
             const data = doc.data();
+            this._adminOrgs = data?.claims?.adminOrgs;
             if (data?.lastUpdated) {
               const lastUpdated = new Date(data!.lastUpdated);
               if (!firekit.claimsLastUpdated || lastUpdated > firekit.claimsLastUpdated) {
@@ -322,7 +323,6 @@ export class RoarFirekit {
       return onIdTokenChanged(this.admin!.auth, async (user) => {
         if (user) {
           const idTokenResult = await user.getIdTokenResult(false);
-          this._adminOrgs = idTokenResult.claims.adminOrgs;
           this._superAdmin = Boolean(idTokenResult.claims.super_admin);
           if (idTokenResult.claims.roarUid) {
             if (this.app?.user) {

--- a/src/firestore/firekit.ts
+++ b/src/firestore/firekit.ts
@@ -1006,6 +1006,7 @@ export class RoarFirekit {
             firebaseProject: this.app,
             userInfo: this.roarAppUserInfo!,
             assigningOrgs,
+            assignmentId: administrationId,
             runId,
             taskInfo,
           });

--- a/src/firestore/query-admin.ts
+++ b/src/firestore/query-admin.ts
@@ -110,7 +110,7 @@ export const getUsersByOrgs = async ({
   isSuperAdmin?: boolean;
   countOnly?: boolean;
 }) => {
-  const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 20 });
+  const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 10 });
   let total = 0;
   const users: IUserData[] = [];
 
@@ -122,6 +122,8 @@ export const getUsersByOrgs = async ({
       isSuperAdmin,
       orgs: orgsChunk,
     });
+
+    console.log(userQuery);
 
     if (userQuery) {
       if (countOnly) {
@@ -154,7 +156,7 @@ export const getAdministrations = async ({
   isSuperAdmin?: boolean;
   includeStats?: boolean;
 }) => {
-  const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 20 });
+  const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 10 });
 
   const administrations: IAdministrationData[] = [];
 
@@ -219,7 +221,7 @@ export const getUsersByAssignment = async ({
   const assignments: IUserAssignmentData[] = [];
 
   if (orgs) {
-    const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 20 });
+    const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 10 });
 
     for (const orgsChunk of chunkedOrgs) {
       const q = buildQueryByAssignment({

--- a/src/firestore/query-admin.ts
+++ b/src/firestore/query-admin.ts
@@ -1,5 +1,8 @@
 import {
+  DocumentData,
+  DocumentSnapshot,
   Firestore,
+  Query,
   and,
   collection,
   collectionGroup,
@@ -13,8 +16,10 @@ import {
 } from 'firebase/firestore';
 import { IAdministrationData, IAssignmentData, IOrgLists, IUserData } from './interfaces';
 import { chunkOrgLists } from './util';
+import _flatten from 'lodash/flatten';
 import _union from 'lodash/union';
 import _uniqBy from 'lodash/uniqBy';
+import _without from 'lodash/without';
 import { getRunById } from './query-assessment';
 
 interface IQueryInput {
@@ -36,6 +41,7 @@ export const buildQueryByOrgs = ({ db, collectionName, nested, isSuperAdmin = fa
   // Cloud Firestore limits a query to a maximum of 30 disjunctions in disjunctive normal form.
   // Detect if there are too many `array-contains` comparisons
   if (_union(...Object.values(orgs)).length > 30) {
+    console.error('Too many orgs', orgs);
     throw new Error('Too many orgs to query. Please chunk orgs such that the total number of orgs is less than 30.');
   }
 
@@ -99,6 +105,23 @@ export const buildQueryByAssignment = ({
   }
 };
 
+const getUsersFromQuery = async ({ query, countOnly = false }: { query: Query<DocumentData>; countOnly?: boolean }) => {
+  if (countOnly) {
+    const snapshot = await getCountFromServer(query);
+    return snapshot.data().count;
+  } else {
+    const users: IUserData[] = [];
+    const snapshot = await getDocs(query);
+    snapshot.forEach((docSnap) => {
+      users.push({
+        id: docSnap.id,
+        ...docSnap.data(),
+      } as IUserData);
+    });
+    return users;
+  }
+};
+
 export const getUsersByOrgs = async ({
   db,
   orgs,
@@ -110,9 +133,8 @@ export const getUsersByOrgs = async ({
   isSuperAdmin?: boolean;
   countOnly?: boolean;
 }) => {
-  const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 10 });
-  let total = 0;
-  const users: IUserData[] = [];
+  const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 20 });
+  const promises: Promise<IUserData[] | number>[] = [];
 
   for (const orgsChunk of chunkedOrgs) {
     const userQuery = buildQueryByOrgs({
@@ -123,26 +145,43 @@ export const getUsersByOrgs = async ({
       orgs: orgsChunk,
     });
 
-    console.log(userQuery);
-
     if (userQuery) {
-      if (countOnly) {
-        const snapshot = await getCountFromServer(userQuery);
-        total += snapshot.data().count;
-      } else {
-        const snapshot = await getDocs(userQuery);
-        snapshot.forEach((docSnap) => {
-          users.push({
-            id: docSnap.id,
-            ...docSnap.data(),
-          } as IUserData);
-        });
-      }
+      promises.push(getUsersFromQuery({ query: userQuery, countOnly }));
     }
   }
 
-  if (countOnly) return total;
-  return _uniqBy(users, (u: IUserData) => u.id);
+  const users = await Promise.all(promises);
+
+  if (countOnly) {
+    return (users as number[]).reduce((prev, curr) => prev + curr, 0);
+  }
+  return _uniqBy(_flatten(users as IUserData[][]), (u: IUserData) => u.id);
+};
+
+const getAdministrationsFromQuery = async ({
+  query,
+  includeStats = true,
+}: {
+  query: Query<DocumentData>;
+  includeStats?: boolean;
+}) => {
+  const administrations: IAdministrationData[] = [];
+  const snapshot = await getDocs(query);
+  for (const docSnap of snapshot.docs) {
+    const docData = docSnap.data();
+    if (includeStats) {
+      const completionDocRef = doc(docSnap.ref, 'stats', 'completion');
+      const completionDocSnap = await getDoc(completionDocRef);
+      if (completionDocSnap.exists()) {
+        docData.stats = completionDocSnap.data();
+      }
+    }
+    administrations.push({
+      id: docSnap.id,
+      ...docData,
+    } as IAdministrationData);
+  }
+  return administrations;
 };
 
 export const getAdministrations = async ({
@@ -156,9 +195,9 @@ export const getAdministrations = async ({
   isSuperAdmin?: boolean;
   includeStats?: boolean;
 }) => {
-  const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 10 });
+  const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 20 });
 
-  const administrations: IAdministrationData[] = [];
+  const promises: Promise<IAdministrationData[]>[] = [];
 
   for (const orgsChunk of chunkedOrgs) {
     const q = buildQueryByOrgs({
@@ -168,27 +207,13 @@ export const getAdministrations = async ({
       orgs: orgsChunk,
       isSuperAdmin,
     });
-    console.log('In getAdministrations: ', { orgsChunk: orgsChunk, query: q });
 
     if (q) {
-      const snapshot = await getDocs(q);
-      for (const docSnap of snapshot.docs) {
-        const docData = docSnap.data();
-        if (includeStats) {
-          const completionDocRef = doc(docSnap.ref, 'stats', 'completion');
-          const completionDocSnap = await getDoc(completionDocRef);
-          if (completionDocSnap.exists()) {
-            docData.stats = completionDocSnap.data();
-          }
-        }
-        administrations.push({
-          id: docSnap.id,
-          ...docData,
-        } as IAdministrationData);
-      }
+      promises.push(getAdministrationsFromQuery({ query: q, includeStats: includeStats }));
     }
   }
 
+  const administrations = _flatten(await Promise.all(promises));
   return _uniqBy(administrations, (a: IAdministrationData) => a.id);
 };
 
@@ -197,6 +222,94 @@ export interface IUserAssignmentData {
   user: IUserData;
   assignment: IAssignmentData;
 }
+
+const getAssignmentData = async ({
+  docSnap,
+  assessmentDb,
+  includeScores = false,
+}: {
+  docSnap: DocumentSnapshot<DocumentData>;
+  assessmentDb: Firestore;
+  includeScores?: boolean;
+}) => {
+  // Now grab the user document and add it to the results.
+  const userRef = docSnap.ref.parent.parent;
+  if (!userRef) {
+    return undefined;
+  }
+  const userDocSnapPromise = getDoc(userRef);
+
+  const assignmentData = docSnap.data() as IAssignmentData;
+  const assessments = assignmentData.assessments;
+  const scoresPromises: Promise<[string, { [key: string]: unknown }][]>[] = [];
+  if (includeScores) {
+    // To retrieve scores, we first build an object where the keys are
+    // the task IDs of each assessment and the values are the scores
+    // for the run associated with that assessment.
+    for (const assessment of assessments) {
+      const runId = assessment.runId;
+      if (runId) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        scoresPromises.push(
+          getRunById({ db: assessmentDb, runId: runId }).then((runData) => [assessment.taskId, runData.scores]),
+        );
+      }
+    }
+  }
+
+  const [userDocSnap, scoresNested] = await Promise.all([userDocSnapPromise, Promise.all(scoresPromises)]);
+
+  if (includeScores) {
+    const scores = _flatten(scoresNested);
+
+    // Now we iterate over the scores and insert them into the
+    // assessments array of objects.
+    for (const [taskId, score] of scores) {
+      const assessmentIdx = assessments.findIndex((a) => a.taskId === taskId);
+      const oldAssessmentInfo = assessments[assessmentIdx];
+      const newAssessmentInfo = {
+        ...oldAssessmentInfo,
+        scores: score,
+      };
+      assessments[assessmentIdx] = newAssessmentInfo;
+    }
+    assignmentData.assessments = assessments;
+  }
+
+  if (userDocSnap.exists()) {
+    return {
+      id: userDocSnap.id,
+      user: userDocSnap.data() as IUserData,
+      assignment: assignmentData,
+    } as IUserAssignmentData;
+  }
+};
+
+const getUsersByAssignmentQuery = async ({
+  assessmentDb,
+  query,
+  countOnly = false,
+  includeScores = false,
+}: {
+  assessmentDb: Firestore;
+  query: Query<DocumentData>;
+  countOnly?: boolean;
+  includeScores?: boolean;
+}) => {
+  if (countOnly) {
+    const snapshot = await getCountFromServer(query);
+    return snapshot.data().count;
+  } else {
+    const assignmentPromises: Promise<IUserAssignmentData | undefined>[] = [];
+    const snapshot = await getDocs(query);
+    for (const docSnap of snapshot.docs) {
+      assignmentPromises.push(getAssignmentData({ docSnap, assessmentDb, includeScores }));
+    }
+
+    const assignments = await Promise.all(assignmentPromises);
+    return assignments;
+  }
+};
 
 export const getUsersByAssignment = async ({
   db,
@@ -217,11 +330,10 @@ export const getUsersByAssignment = async ({
     throw new Error('You must provide an assessmentDb if you want to include scores.');
   }
 
-  let total = 0;
-  const assignments: IUserAssignmentData[] = [];
+  const assignmentsPromises: Promise<(IUserAssignmentData | undefined)[] | number>[] = [];
 
   if (orgs) {
-    const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 10 });
+    const chunkedOrgs = chunkOrgLists({ orgs, chunkSize: 20 });
 
     for (const orgsChunk of chunkedOrgs) {
       const q = buildQueryByAssignment({
@@ -231,61 +343,24 @@ export const getUsersByAssignment = async ({
       });
 
       if (q) {
-        if (countOnly) {
-          const snapshot = await getCountFromServer(q);
-          total += snapshot.data().count;
-        } else {
-          const snapshot = await getDocs(q);
-          for (const docSnap of snapshot.docs) {
-            const assignmentData = docSnap.data() as IAssignmentData;
-
-            if (includeScores) {
-              // To retrieve scores, we first build an object where the keys are
-              // the task IDs of each assessment and the values are the scores
-              // for the run associated with that assessment.
-              const assessments = assignmentData.assessments;
-              const scores: { [key: string]: unknown } = {};
-              for (const assessment of assessments) {
-                const runId = assessment.runId;
-                if (runId) {
-                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  const { scores: runScores } = await getRunById({ db: assessmentDb!, runId });
-                  scores[assessment.taskId] = runScores;
-                }
-              }
-
-              // Now we iterate over the scores and insert them into the
-              // assessments array of objects.
-              for (const [taskId, score] of Object.entries(scores)) {
-                const assessmentIdx = assessments.findIndex((a) => a.taskId === taskId);
-                const oldAssessmentInfo = assessments[assessmentIdx];
-                const newAssessmentInfo = {
-                  ...oldAssessmentInfo,
-                  scores: score,
-                };
-                assessments[assessmentIdx] = newAssessmentInfo;
-              }
-              assignmentData.assessments = assessments;
-            }
-
-            // Now grab the user document and add it to the results.
-            const userRef = docSnap.ref.parent.parent;
-            if (userRef) {
-              const userDocSnap = await getDoc(userRef);
-              if (userDocSnap.exists()) {
-                assignments.push({
-                  id: userDocSnap.id,
-                  user: userDocSnap.data() as IUserData,
-                  assignment: assignmentData,
-                });
-              }
-            }
-          }
-        }
+        assignmentsPromises.push(
+          getUsersByAssignmentQuery({
+            assessmentDb,
+            query: q,
+            countOnly,
+            includeScores,
+          }),
+        );
       }
     }
   }
 
-  if (countOnly) return total;
-  return _uniqBy(assignments, (u: IUserAssignmentData) => u.id);
+  const assignments = await Promise.all(assignmentsPromises);
+
+  if (countOnly) {
+    return (assignments as number[]).reduce((prev, curr) => prev + curr, 0);
+  }
+
+  const assignmentsFlat = _flatten(assignments as (IUserAssignmentData | undefined)[][]).filter((a) => a !== undefined);
+  return _uniqBy(assignmentsFlat as IUserAssignmentData[], (a: IUserAssignmentData) => a.id);
 };

--- a/src/firestore/query-assessment.ts
+++ b/src/firestore/query-assessment.ts
@@ -32,7 +32,7 @@ export const getOrganizations = async (db: Firestore, orgType: OrgCollectionName
   }
 
   const orgs = [];
-  const maxQueryDisjunctions = 20;
+  const maxQueryDisjunctions = 10;
   for (const _orgsChunk of _chunk(orgIds, maxQueryDisjunctions)) {
     q = query(collection(db, orgType), where(documentId(), 'in', _orgsChunk));
     const snapshot = await getDocs(q);

--- a/src/firestore/util.ts
+++ b/src/firestore/util.ts
@@ -486,11 +486,6 @@ export const chunkOrgLists = ({ orgs, chunkSize = 30 }: { orgs?: IOrgLists; chun
     }),
   );
 
-  console.log('In chunkOrgLists', {
-    orgs,
-    orgPairs,
-  });
-
   if (orgPairs.length <= chunkSize) return [orgs];
 
   const chunkedOrgs = _chunk(orgPairs, chunkSize);


### PR DESCRIPTION
This PR limits the size of org chunks in queries in order to satisfy firestore security rule limitations on the number of get requests per query.

It also retrieves the user's adminOrgs from firestore rather than the custom auth claims