### PR TITLE
update addEngagementByBlock method to store reliableByBlock attribute for block-scoped assessments

### DIFF
--- a/src/firestore/app/appkit.ts
+++ b/src/firestore/app/appkit.ts
@@ -201,6 +201,27 @@ export class RoarAppkit {
   }
 
   /**
+   * Update the engagement flags for the current run in a block-based administration.
+   *
+   * @param {string[]} flagNames - The names of the engagement flags to add.
+   * @param {boolean} markAsReliable - Whether or not to mark the run as reliable, defaults to false
+   * @param {Object} reliableByBlock - Stores the reliability of the run by block
+   * For Example: {DEL: false, FSM: true, LSM: false}
+   * @method
+   * @async
+   *
+   * Please note that calling this function with a new set of engagement flags will
+   * overwrite the previous set.
+   */
+  async updateEngagementFlagsByBlock(flagNames: string[], markAsReliable = false, reliableByBlock = {}) {
+    if (this._started) {
+      return this.run!.addEngagementFlagsByBlock(flagNames, markAsReliable, reliableByBlock);
+    } else {
+      throw new Error('This run has not started. Use the startRun method first.');
+    }
+  }
+
+  /**
    * Finish the ROAR run by marking it as finished in Firestore.
    * Call this method after the jsPsych experiment finishes. For example:
    *

--- a/src/firestore/app/appkit.ts
+++ b/src/firestore/app/appkit.ts
@@ -192,30 +192,9 @@ export class RoarAppkit {
    * Please note that calling this function with a new set of engagement flags will
    * overwrite the previous set.
    */
-  async updateEngagementFlags(flagNames: string[], markAsReliable = false) {
+  async updateEngagementFlags(flagNames: string[], markAsReliable = false, reliableByBlock = undefined) {
     if (this._started) {
-      return this.run!.addEngagementFlags(flagNames, markAsReliable);
-    } else {
-      throw new Error('This run has not started. Use the startRun method first.');
-    }
-  }
-
-  /**
-   * Update the engagement flags for the current run in a block-based administration.
-   *
-   * @param {string[]} flagNames - The names of the engagement flags to add.
-   * @param {boolean} markAsReliable - Whether or not to mark the run as reliable, defaults to false
-   * @param {Object} reliableByBlock - Stores the reliability of the run by block
-   * For Example: {DEL: false, FSM: true, LSM: false}
-   * @method
-   * @async
-   *
-   * Please note that calling this function with a new set of engagement flags will
-   * overwrite the previous set.
-   */
-  async updateEngagementFlagsByBlock(flagNames: string[], markAsReliable = false, reliableByBlock = {}) {
-    if (this._started) {
-      return this.run!.addEngagementFlagsByBlock(flagNames, markAsReliable, reliableByBlock);
+      return this.run!.addEngagementFlags(flagNames, markAsReliable, reliableByBlock);
     } else {
       throw new Error('This run has not started. Use the startRun method first.');
     }

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -238,6 +238,35 @@ export class RoarRun {
   }
 
   /**
+   * Add engagement flags to a run.
+   * @method
+   * @async
+   * @param {string[]} engagementFlags - Engagement flags to add to the run
+   * @param {boolean} markAsReliable - Whether or not to mark the run as reliable, defaults to false 
+   * @param {Object} reliableByBlock - Stores the reliability of the run by block
+   * For Example: {DEL: false, FSM: true, LSM: false}
+   * 
+   * Please note that calling this function with a new set of engagement flags will 
+   * overwrite the previous set. 
+   */
+  async addEngagementFlagsByBlock(engagementFlags: string[], markAsReliable = false, reliableByBlock = {}) {
+    if (!this.started) {
+      throw new Error('Run has not been started yet. Use the startRun method first.');
+    }
+
+    const engagementObj = engagementFlags.reduce((acc: { [x: string]: unknown }, flag) => {
+      acc[flag] = true;
+      return acc;
+    }, {});
+
+    if (!this.aborted) {
+      return updateDoc(this.runRef, { engagementFlags: engagementObj, reliable: markAsReliable, reliableByBlock: reliableByBlock });
+    } else {
+      throw new Error('Run has already been aborted.');
+    }
+  }
+
+  /**
    * Mark this run as complete on Firestore
    * @method
    * @async


### PR DESCRIPTION
The `updateEngagementFlagsByBlock` method is similar to the `updateEngagementFlags` previously declared, but adds on functionality to update the `reliableByBlock` attribute under runs. This attribute is a dictionary that allows for indication of reliability by block. 