### PR TITLE
Revert "Switch back to ISC License"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,20 @@
-ISC License
+STANFORD ACADEMIC SOFTWARE LICENSE FOR ROAR™
+Stanford Docket S21-342: "Rapid Online Assessment of Reading "ROAR™")"
 
-Copyright (c) 2025 The ROAR Developer Consortium
+Please address any communications to: jyeatman@stanford.edu and otl@stanford.edu 
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+By accessing the software in this folder, you are agreeing to the license terms listed below.
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE.
+1. THE BOARD OF TRUSTEES OF THE LELAND STANFORD JUNIOR UNIVERSITY (“Stanford”) has an assignment to "Rapid Online Assessment of Reading ("ROAR™")" ("Software"), described in Stanford Docket S21-342, which was developed by Professor Jason Yeatman in the Graduate School of Education. 
+2. By accessing, downloading, accepting, receiving, or using Software, including any accompanying information, materials or manuals you ("RECIPIENT") are agreeing to be bound by the terms of this License.  If you do not agree to the terms of this License, do not download any files from this directory.
+3. STANFORD grants to RECIPIENT a royalty-free, nonexclusive, and nontransferable license to use the Software furnished hereunder, upon the terms and conditions set out below. 
+4. RECIPIENT acknowledges that the Software is a research tool still in the development stage and that it is being supplied as is, without any accompanying services, support or improvements from STANFORD.  STANFORD makes no representations and extends no warranties of any kind, either express or implied other than set out in this License.
+5. RECIPIENT agrees to use the Software solely for internal academic, non-commercial purposes and shall not distribute or transfer the Software or any of its derivatives or enhancements from RECIPIENT to another location or to any other person without prior written permission from STANFORD.
+6. RECIPIENT agrees not to reverse engineer, reverse assemble, reverse compile decompile, disassemble, or otherwise attempt to re-create the source code for the Software. RECIPIENT acknowledges that any programs created based on the Software will be considered a derivative of Software and owned by STANFORD. 
+7. RECIPIENT may make modifications to the Software and integrate Software into RECIPIENT's own software.    All derivative works and enhancements are owned by Stanford.
+8. RECIPIENT may not further distribute Software or its derivatives or enhancements without express written permission of STANFORD. If permission to transfer the Software is given, RECIPIENT warrants that RECIPIENT will not remove or export any part of the Software from the United States except in full compliance with all United States export regulations and other applicable laws.
+9. RECIPIENT will use the Software in compliance with all applicable laws, policies and regulations including, but not limited to, any approvals, informed consent and patient confidentiality principles.
+10. RECIPIENT will indemnify, hold harmless, and defend STANFORD against any claim of any kind arising out of or related to the exercise of any rights granted under this License or the breach of this License by RECIPIENT.
+11. Title and copyright to the Software and any derivatives and any associated documentation shall at all times remain with STANFORD, and RECIPIENT agrees to preserve same.
+12. If RECIPIENT plans to publish any peer reviewed papers, abstracts, or similar publications, RECIPIENT agrees to acknowledge Software and its creator, Professor Jason Yeatman, in a manner consistent with academic (industry) practice. 
+13. If RECIPIENT decides to terminate this License, RECIPIENT shall destroy or return immediately all Software and all derivative works.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/yeatmanlab/roar-firekit.git"
+    "url": "git+https://github.com/richford/roar-firekit.git"
   },
   "keywords": [
     "firebase",
@@ -35,12 +35,12 @@
     "literacy",
     "dyslexia"
   ],
-  "author": "Adam Richie-Halford <adamrh@stanford.edu>",
+  "author": "Adam Richie-Halford <richiehalford@gmail.com> (https://richiehalford.org/)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/yeatmanlab/roar-firekit/issues"
+    "url": "https://github.com/richford/roar-firekit/issues"
   },
-  "homepage": "https://github.com/yeatmanlab/roar-firekit#readme",
+  "homepage": "https://github.com/richford/roar-firekit#readme",
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
     "@firebase/rules-unit-testing": "^2.0.2",


### PR DESCRIPTION
This PR Reverts yeatmanlab/roar-firekit#181, switching back to the SAL license after discussion with @jyeatman.